### PR TITLE
@ctx.irep_node.definitions no longer returns a type deff

### DIFF
--- a/lib/graphql/rails/resolver.rb
+++ b/lib/graphql/rails/resolver.rb
@@ -134,7 +134,7 @@ module GraphQL
       end
 
       def has_id_argument?
-        @ctx.irep_node.definitions.any? do |type_defn, field_defn|
+        @ctx.irep_node.definitions.any? do |field_defn|
           if field_defn.name === field_name
             field_defn.arguments.any? do |k,v|
               is_field_id_type?(v.type)
@@ -156,11 +156,11 @@ module GraphQL
       end
 
       def connection?
-        @ctx.irep_node.definitions.all? { |type_defn, field_defn| field_defn.resolve_proc.is_a?(GraphQL::Relay::ConnectionResolve) }
+        @ctx.irep_node.definitions.all? { |field_defn| field_defn.resolve_proc.is_a?(GraphQL::Relay::ConnectionResolve) }
       end
 
       def list?
-        @ctx.irep_node.definitions.all? { |type_defn, field_defn| field_defn.type.kind.eql?(GraphQL::TypeKinds::LIST) }
+        @ctx.irep_node.definitions.all? { |field_defn| field_defn.type.kind.eql?(GraphQL::TypeKinds::LIST) }
       end
 
       def get_field_args


### PR DESCRIPTION
Playing around with graphql-rails and this gem I noticed that `type_defn` was returning the field def.  After inspecting I saw that only one attribute was being returned. 